### PR TITLE
feat(spacecraft): Add PR 1 initialization skeleton

### DIFF
--- a/src/run_all.py
+++ b/src/run_all.py
@@ -1,6 +1,38 @@
+import logging
+import sys
+
+# Ensure basic logging is configured
+logging.basicConfig(level=logging.INFO, format='%(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
 def main():
-    print("MissionOps Copilot: run_all placeholder")
-    print("TODO: run aircraft module then spacecraft module and write outputs/")
+    """
+    Week 1 stub.
+    Tech debt: replace with argparse CLI + logging module + sys.exit(1) on failure before Week 3.
+    """
+    print("MissionOps Copilot: run_all execution")
+    
+    success = True
+
+    # Aircraft Module (Placeholder)
+    try:
+        print("--- Running Aircraft Module ---")
+        # TODO: run aircraft module
+        print("Aircraft module placeholder complete.")
+    except Exception as e:
+        logger.error(f"Aircraft module failed: {e}")
+        success = False
+
+    # Spacecraft Module (Minimal PR #1 Stub)
+    try:
+        print("--- Running Spacecraft Module ---")
+        print("spacecraft: ok")
+    except Exception as e:
+        logger.error(f"Spacecraft module failed: {e}")
+        success = False
+
+    if not success:
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/src/spacecraft/models.py
+++ b/src/spacecraft/models.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, auto
 

--- a/src/spacecraft/models.py
+++ b/src/spacecraft/models.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum, auto
+
+
+class TaskType(Enum):
+    """Enumeration for spacecraft task types."""
+    CONTACT = auto()
+    OBSERVATION = auto()
+    DOWNLINK = auto()
+
+
+@dataclass
+class Window:
+    """Represents a time window for a specific task type."""
+    start_time: datetime
+    end_time: datetime
+    window_type: TaskType
+
+    def duration(self) -> float:
+        """Returns the duration of the window in seconds."""
+        return (self.end_time - self.start_time).total_seconds()
+
+
+@dataclass
+class Task:
+    """
+    Represents a scheduled spacecraft task.
+    In Week 1, this maps 1:1 with a Window, but represents an assigned/locked action.
+    """
+    task_id: str
+    target: str
+    start_time: datetime
+    end_time: datetime
+    task_type: TaskType
+    priority: int = 1  # 1 is highest priority
+
+    def duration(self) -> float:
+        return (self.end_time - self.start_time).total_seconds()
+
+
+@dataclass
+class ConstraintViolation:
+    """Represents a schedule constraint violation."""
+    constraint_name: str
+    description: str
+    time_of_violation: datetime | None = None


### PR DESCRIPTION
## PR #1 — Spacecraft Ops Skeleton

- `src/spacecraft/__init__.py` — module init
- `src/spacecraft/models.py` — TaskType enum + Window/Task/ConstraintViolation dataclasses
- `outputs/spacecraft/.gitkeep` — output dir tracked for CI
- `src/run_all.py` — stubbed with logging, try/except, sys.exit(1)

Week 1 skeleton increment. Full orbit/scheduler/constraints/viz in PR #2.